### PR TITLE
Updated "ota:" example config entry with platform key

### DIFF
--- a/esphome/template.yaml
+++ b/esphome/template.yaml
@@ -40,7 +40,8 @@ wifi:
 captive_portal:
 
 ota:
-  password: ""
+  - platform: esphome
+    password: ""
 
 logger:
   level: DEBUG


### PR DESCRIPTION
(venv) PS C:\Users\xxx\Documents\ESPhome\esphome-toshiba-hvac-controller\esphome> esphome compile toshiba-vp.yaml
INFO ESPHome 2024.11.3
INFO Reading configuration toshiba-vp.yaml...
Failed config

ota.unknown: [source toshiba-vp.yaml:46]

  'ota' requires a 'platform' key but it was not specified.
  password: '