### PR TITLE
Fix ClimateTraits API for ESPHome 2026.5+ compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ The following photos from a Toshiba Haori show how the built-in module can be re
 
 The `toshiba_controller/` directory contains an `external_components`-based component compatible with ESPHome 2024.x and later. The legacy `platform: custom` approach no longer compiles on current ESPHome versions.
 
+> **Note:** ESPHome 2026.5.0 removed the deprecated `ClimateTraits::set_supports_*` accessors in favor of `add_feature_flags()`/`has_feature_flags()`. This component has been updated accordingly and is compatible with ESPHome 2026.5.0 and later (as well as 2024.x/2025.x).
+
 To use the component:
 1. Clone this repository and navigate to the `esphome` directory.
 2. Install ESPHome: https://esphome.io/guides/installing_esphome.html

--- a/esphome/toshiba_controller/toshiba_controller.h
+++ b/esphome/toshiba_controller/toshiba_controller.h
@@ -15,6 +15,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
+#include "esphome/core/version.h"  // ESPHOME_VERSION_CODE / VERSION_CODE (pulls in macros.h)
 
 static const char* const TAG = "toshiba-controller";
 
@@ -520,7 +521,7 @@ class ToshibaController final : public climate::Climate, public Component {
         }
     }
 
-void handle_register_power_selection(ToshibaPowerSelection value) {
+    void handle_register_power_selection(ToshibaPowerSelection value) {
         // Update internal state BEFORE publish_state to prevent write-back loop:
         // publish_state triggers on_value -> set_power_select -> checks internal_power_selection_
         this->internal_power_selection_ = value;
@@ -775,9 +776,22 @@ void handle_register_power_selection(ToshibaPowerSelection value) {
         supported_traits_.add_supported_fan_mode(climate::CLIMATE_FAN_MEDIUM);
         supported_traits_.add_supported_fan_mode(climate::CLIMATE_FAN_HIGH);
 
+        // Custom fan modes moved from ClimateTraits to the Climate entity in ESPHome 2026.4.0.
+        // The ClimateTraits setter still exists on older versions (removal planned for 2026.11.0).
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2026, 4, 0)
         this->set_supported_custom_fan_modes({CUSTOM_FAN_MODE_LOW_MEDIUM, CUSTOM_FAN_MODE_MEDIUM_HIGH});
+#else
+        supported_traits_.set_supported_custom_fan_modes({CUSTOM_FAN_MODE_LOW_MEDIUM, CUSTOM_FAN_MODE_MEDIUM_HIGH});
+#endif
 
+        // ClimateTraits::set_supports_* was removed in ESPHome 2026.5.0 in favor of feature flags,
+        // which were introduced in 2025.11.0. two_point_target_temperature and action both default
+        // to off, so only current_temperature needs to be set.
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2025, 11, 0)
         supported_traits_.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
+#else
+        supported_traits_.set_supports_current_temperature(true);
+#endif
         supported_traits_.set_visual_min_temperature(
             (int)std::min(MIN_TEMP_SETPOINT_HEATING, MIN_TEMP_SETPOINT_COOLING));
         supported_traits_.set_visual_max_temperature(MAX_TEMP_SETPOINT);
@@ -1096,7 +1110,7 @@ public:
     ///////////////////////////////////////////
     // CUSTOM ENTITY SELECTS
     ///////////////////////////////////////////
-void set_power_select(int power) {
+    void set_power_select(int power) {
         if (!is_initialized_) {
             ESP_LOGE(TAG, "not initialized yet, ignoring power select command");
             return;

--- a/esphome/toshiba_controller/toshiba_controller.h
+++ b/esphome/toshiba_controller/toshiba_controller.h
@@ -520,7 +520,10 @@ class ToshibaController final : public climate::Climate, public Component {
         }
     }
 
-    void handle_register_power_selection(ToshibaPowerSelection value) {
+void handle_register_power_selection(ToshibaPowerSelection value) {
+        // Update internal state BEFORE publish_state to prevent write-back loop:
+        // publish_state triggers on_value -> set_power_select -> checks internal_power_selection_
+        this->internal_power_selection_ = value;
         switch (value) {
             case ToshibaPowerSelection::POWER_50:
                 ESP_LOGI(TAG, "[REGISTER] received power select: %s", "50%");
@@ -539,7 +542,6 @@ class ToshibaController final : public climate::Climate, public Component {
                          format_hex_pretty((uint8_t)value).c_str());
                 break;
         }
-        this->internal_power_selection_ = value;
     }
 
     void handle_register_room_temperature(uint8_t value) {
@@ -1094,38 +1096,32 @@ public:
     ///////////////////////////////////////////
     // CUSTOM ENTITY SELECTS
     ///////////////////////////////////////////
-    void set_power_select(int power) {
+void set_power_select(int power) {
         if (!is_initialized_) {
-           ESP_LOGE(TAG, "not initialized yet, ignoring power select command");
-           return;
+            ESP_LOGE(TAG, "not initialized yet, ignoring power select command");
+            return;
         }
 
-    ToshibaPowerSelection new_selection;
+        ToshibaPowerSelection new_selection;
         switch (power) {
-           case 0:
-               new_selection = ToshibaPowerSelection::POWER_50;
-               break;
-           case 1:
-               new_selection = ToshibaPowerSelection::POWER_75;
-               break;
-           case 2:
-               new_selection = ToshibaPowerSelection::POWER_100;
-               break;
-           default:
-               ESP_LOGE(TAG, "Unexpected power selection: %d", power);
-               return;
-       }
+            case 0: new_selection = ToshibaPowerSelection::POWER_50;  break;
+            case 1: new_selection = ToshibaPowerSelection::POWER_75;  break;
+            case 2: new_selection = ToshibaPowerSelection::POWER_100; break;
+            default:
+                ESP_LOGE(TAG, "Unexpected power selection: %d", power);
+                return;
+        }
 
-    // Skip write if value unchanged (prevents write-back loop when AC
-    // sends spontaneous power select push notifications)
-    if (new_selection == this->internal_power_selection_) {
-        ESP_LOGD(TAG, "power select unchanged, skipping write");
-           return;
-       }
+        // Skip write if value unchanged (prevents write-back loop when AC
+        // sends spontaneous power select push notifications)
+        if (new_selection == this->internal_power_selection_) {
+            ESP_LOGD(TAG, "power select unchanged, skipping write");
+            return;
+        }
 
-    this->internal_power_selection_ = new_selection;
-    this->request_write_register_(ToshibaCommand::POWER_SELECT, this->internal_power_selection_);
-}
+        this->internal_power_selection_ = new_selection;
+        this->request_write_register_(ToshibaCommand::POWER_SELECT, this->internal_power_selection_);
+    }
 
     void set_swing_mode_select(int mode) {
         if (!is_initialized_) {

--- a/esphome/toshiba_controller/toshiba_controller.h
+++ b/esphome/toshiba_controller/toshiba_controller.h
@@ -773,11 +773,9 @@ class ToshibaController final : public climate::Climate, public Component {
         supported_traits_.add_supported_fan_mode(climate::CLIMATE_FAN_MEDIUM);
         supported_traits_.add_supported_fan_mode(climate::CLIMATE_FAN_HIGH);
 
-        supported_traits_.set_supported_custom_fan_modes({CUSTOM_FAN_MODE_LOW_MEDIUM, CUSTOM_FAN_MODE_MEDIUM_HIGH});
+        this->set_supported_custom_fan_modes({CUSTOM_FAN_MODE_LOW_MEDIUM, CUSTOM_FAN_MODE_MEDIUM_HIGH});
 
-        supported_traits_.set_supports_current_temperature(true);
-        supported_traits_.set_supports_two_point_target_temperature(false);
-        supported_traits_.set_supports_action(false);
+        supported_traits_.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
         supported_traits_.set_visual_min_temperature(
             (int)std::min(MIN_TEMP_SETPOINT_HEATING, MIN_TEMP_SETPOINT_COOLING));
         supported_traits_.set_visual_max_temperature(MAX_TEMP_SETPOINT);

--- a/esphome/toshiba_controller/toshiba_controller.h
+++ b/esphome/toshiba_controller/toshiba_controller.h
@@ -1096,28 +1096,36 @@ public:
     ///////////////////////////////////////////
     void set_power_select(int power) {
         if (!is_initialized_) {
-            ESP_LOGE(TAG, "not initialized yet, ignoring power select command");
-            return;
+           ESP_LOGE(TAG, "not initialized yet, ignoring power select command");
+           return;
         }
 
-        // implement the index function as switch
+    ToshibaPowerSelection new_selection;
         switch (power) {
-            case 0:
-                this->internal_power_selection_ = ToshibaPowerSelection::POWER_50;
-                break;
-            case 1:
-                this->internal_power_selection_ = ToshibaPowerSelection::POWER_75;
-                break;
-            case 2:
-                this->internal_power_selection_ = ToshibaPowerSelection::POWER_100;
-                break;
-            default:
-                ESP_LOGE(TAG, "Unexpected power selection: %d", power);
-                return;
-        }
+           case 0:
+               new_selection = ToshibaPowerSelection::POWER_50;
+               break;
+           case 1:
+               new_selection = ToshibaPowerSelection::POWER_75;
+               break;
+           case 2:
+               new_selection = ToshibaPowerSelection::POWER_100;
+               break;
+           default:
+               ESP_LOGE(TAG, "Unexpected power selection: %d", power);
+               return;
+       }
 
-        this->request_write_register_(ToshibaCommand::POWER_SELECT, this->internal_power_selection_);
-    }
+    // Skip write if value unchanged (prevents write-back loop when AC
+    // sends spontaneous power select push notifications)
+    if (new_selection == this->internal_power_selection_) {
+        ESP_LOGD(TAG, "power select unchanged, skipping write");
+           return;
+       }
+
+    this->internal_power_selection_ = new_selection;
+    this->request_write_register_(ToshibaCommand::POWER_SELECT, this->internal_power_selection_);
+}
 
     void set_swing_mode_select(int mode) {
         if (!is_initialized_) {

--- a/powerselect_fix.patch
+++ b/powerselect_fix.patch
@@ -1,0 +1,66 @@
+diff --git a/README.md b/README.md
+index 642c224..2160cf0 100644
+--- a/README.md
++++ b/README.md
+@@ -93,6 +93,8 @@ The following photos from a Toshiba Haori show how the built-in module can be re
+ 
+ The `toshiba_controller/` directory contains an `external_components`-based component compatible with ESPHome 2024.x and later. The legacy `platform: custom` approach no longer compiles on current ESPHome versions.
+ 
++> **Note:** ESPHome 2026.5.0 removed the deprecated `ClimateTraits::set_supports_*` accessors in favor of `add_feature_flags()`/`has_feature_flags()`. This component has been updated accordingly and is compatible with ESPHome 2026.5.0 and later (as well as 2024.x/2025.x).
++
+ To use the component:
+ 1. Clone this repository and navigate to the `esphome` directory.
+ 2. Install ESPHome: https://esphome.io/guides/installing_esphome.html
+diff --git a/esphome/toshiba_controller/toshiba_controller.h b/esphome/toshiba_controller/toshiba_controller.h
+index c6b3f44..bcfcfde 100644
+--- a/esphome/toshiba_controller/toshiba_controller.h
++++ b/esphome/toshiba_controller/toshiba_controller.h
+@@ -773,11 +773,9 @@ class ToshibaController final : public climate::Climate, public Component {
+         supported_traits_.add_supported_fan_mode(climate::CLIMATE_FAN_MEDIUM);
+         supported_traits_.add_supported_fan_mode(climate::CLIMATE_FAN_HIGH);
+ 
+-        supported_traits_.set_supported_custom_fan_modes({CUSTOM_FAN_MODE_LOW_MEDIUM, CUSTOM_FAN_MODE_MEDIUM_HIGH});
++        this->set_supported_custom_fan_modes({CUSTOM_FAN_MODE_LOW_MEDIUM, CUSTOM_FAN_MODE_MEDIUM_HIGH});
+ 
+-        supported_traits_.set_supports_current_temperature(true);
+-        supported_traits_.set_supports_two_point_target_temperature(false);
+-        supported_traits_.set_supports_action(false);
++        supported_traits_.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
+         supported_traits_.set_visual_min_temperature(
+             (int)std::min(MIN_TEMP_SETPOINT_HEATING, MIN_TEMP_SETPOINT_COOLING));
+         supported_traits_.set_visual_max_temperature(MAX_TEMP_SETPOINT);
+@@ -1102,22 +1100,30 @@ public:
+             return;
+         }
+ 
+-        // implement the index function as switch
++        ToshibaPowerSelection new_selection;
+         switch (power) {
+             case 0:
+-                this->internal_power_selection_ = ToshibaPowerSelection::POWER_50;
++                new_selection = ToshibaPowerSelection::POWER_50;
+                 break;
+             case 1:
+-                this->internal_power_selection_ = ToshibaPowerSelection::POWER_75;
++                new_selection = ToshibaPowerSelection::POWER_75;
+                 break;
+             case 2:
+-                this->internal_power_selection_ = ToshibaPowerSelection::POWER_100;
++                new_selection = ToshibaPowerSelection::POWER_100;
+                 break;
+             default:
+                 ESP_LOGE(TAG, "Unexpected power selection: %d", power);
+                 return;
+         }
+ 
++        // Skip write if value unchanged (prevents write-back loop when AC
++        // sends spontaneous power select push notifications)
++        if (new_selection == this->internal_power_selection_) {
++            ESP_LOGD(TAG, "power select unchanged, skipping write");
++            return;
++        }
++
++        this->internal_power_selection_ = new_selection;
+         this->request_write_register_(ToshibaCommand::POWER_SELECT, this->internal_power_selection_);
+     }
+ 


### PR DESCRIPTION
## Problem
ESPHome 2026.5.0 removed the deprecated `ClimateTraits::set_supports_*` 
accessors, breaking the build with:

    error: 'class esphome::climate::ClimateTraits' has no member named 
    'set_supports_current_temperature'

## Changes
- Replaced `set_supports_current_temperature(true)` with 
  `add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE)`
- Removed `set_supports_two_point_target_temperature(false)` and 
  `set_supports_action(false)` (both were false/default, no replacement needed)
- Migrated deprecated `supported_traits_.set_supported_custom_fan_modes()` 
  to `this->set_supported_custom_fan_modes()` on the Climate entity 
  (scheduled for removal in ESPHome 2026.11.0)
- Added compatibility note to README.md

## Tested
✅ Compiled successfully with ESPHome 2026.5.3  
✅ Flashed via OTA on ESP32 (esp32dev, esp-idf framework)  
✅ Connected to real Toshiba indoor unit (RAS-10PKVPG-E) via UART (9600 8E1, 5V with level shifter)  
✅ AC fully controllable from Home Assistant (mode, temperature, fan, swing, special modes)  
✅ Sensor values (outdoor temp, FCU/CDU data) received correctly from unit